### PR TITLE
Add deploy step to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,18 @@ jobs:
       with:
         node-version: '14.7'
     - run: make frontend
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.7'
+    - run: make frontend-build
+    - run: mv out/public out/pr${{ github.event.number }}
+    - uses: GoogleCloudPlatform/github-actions/upload-cloud-storage@master
+      with:
+        credentials: ${{ secrets.gcp_credentials }}
+        path: out/pr${{ github.event.number }}
+        destination: triangulation31/covid19

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,21 @@
+name: pr comment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `On successful build preview at [covid19/pr${context.payload.pull_request.number}](https://storage.googleapis.com/triangulation31/covid19/pr${context.payload.pull_request.number}/index.html).`
+            })
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /frontend/node_modules/
-/frontend/public/build/
+/frontend/public/bundle.*
 /out/

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,11 +6,11 @@
 
     <title>Svelte app</title>
 
-    <link rel="icon" type="image/png" href="/favicon.png" />
-    <link rel="stylesheet" href="/global.css" />
-    <link rel="stylesheet" href="/build/bundle.css" />
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="stylesheet" href="global.css" />
+    <link rel="stylesheet" href="bundle.css" />
 
-    <script defer src="/build/bundle.js"></script>
+    <script defer src="bundle.js"></script>
   </head>
 
   <body></body>

--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -13,12 +13,12 @@ export default {
     sourcemap: true,
     format: "iife",
     name: "app",
-    file: "public/build/bundle.js",
+    file: "public/bundle.js",
   },
   plugins: [
     svelte({
       dev: !production,
-      css: (css) => css.write("public/build/bundle.css"),
+      css: (css) => css.write("public/bundle.css"),
     }),
 
     resolve({


### PR DESCRIPTION
Add deploy to GCP bucket step to CI so that PR changes can be live
reviewed.

- Use relative paths in index.html so that frontend can be served from non-root URL path (e.g. bucket)
- Add CI job `deploy` that rebuilds frontend without linting and copies result to storage bucket
- Add GitHub action to comment on PR with preview URL